### PR TITLE
 Issue 1476: LedgerEntry is recycled twice at ReadLastConfirmedAndEntryOp

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/BookKeeper.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/BookKeeper.java
@@ -738,6 +738,10 @@ public class BookKeeper implements org.apache.bookkeeper.client.api.BookKeeper {
         }
     }
 
+    boolean shouldReorderReadSequence() {
+        return reorderReadSequence;
+    }
+
     ZooKeeper getZkHandle() {
         return ((ZKMetadataClientDriver) metadataDriver).getZk();
     }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/ReadLastConfirmedAndEntryOp.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/ReadLastConfirmedAndEntryOp.java
@@ -465,7 +465,6 @@ class ReadLastConfirmedAndEntryOp implements BookkeeperInternalCallbacks.ReadEnt
         return lh.getBk().getMainWorkerPool().submitOrdered(lh.getId(), new Callable<Boolean>() {
             @Override
             public Boolean call() throws Exception {
-                LOG.info("Attempt to issue specultive requests");
                 if (!requestComplete.get() && !request.isComplete()
                         && (null != request.maybeSendSpeculativeRead(heardFromHostsBitSet))) {
                     if (LOG.isDebugEnabled()) {
@@ -559,7 +558,7 @@ class ReadLastConfirmedAndEntryOp implements BookkeeperInternalCallbacks.ReadEnt
 
             if (entryId != BookieProtocol.LAST_ADD_CONFIRMED) {
                 buffer.retain();
-                if (request.complete(rCtx.getBookieIndex(), bookie, buffer, entryId)) {
+                if (!requestComplete.get() && request.complete(rCtx.getBookieIndex(), bookie, buffer, entryId)) {
                     // callback immediately
                     if (rCtx.getLacUpdateTimestamp().isPresent()) {
                         long elapsedMicros = TimeUnit.MILLISECONDS.toMicros(System.currentTimeMillis()

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/impl/LastConfirmedAndEntryImpl.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/impl/LastConfirmedAndEntryImpl.java
@@ -41,11 +41,15 @@ public class LastConfirmedAndEntryImpl implements LastConfirmedAndEntry {
     public static LastConfirmedAndEntryImpl create(long lac, org.apache.bookkeeper.client.LedgerEntry entry) {
         LastConfirmedAndEntryImpl entryImpl = RECYCLER.get();
         entryImpl.lac = lac;
-        entryImpl.entry = LedgerEntryImpl.create(
-            entry.getLedgerId(),
-            entry.getEntryId(),
-            entry.getLength(),
-            entry.getEntryBuffer());
+        if (null == entry) {
+            entryImpl.entry = null;
+        } else {
+            entryImpl.entry = LedgerEntryImpl.create(
+                entry.getLedgerId(),
+                entry.getEntryId(),
+                entry.getLength(),
+                entry.getEntryBuffer());
+        }
         return entryImpl;
     }
 

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/ReadLastConfirmedAndEntryOpTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/ReadLastConfirmedAndEntryOpTest.java
@@ -1,0 +1,191 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.bookkeeper.client;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.google.common.base.Optional;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.bookkeeper.client.BKException.Code;
+import org.apache.bookkeeper.client.BookKeeper.DigestType;
+import org.apache.bookkeeper.client.ReadLastConfirmedAndEntryOp.LastConfirmedAndEntryCallback;
+import org.apache.bookkeeper.client.api.LastConfirmedAndEntry;
+import org.apache.bookkeeper.client.impl.LastConfirmedAndEntryImpl;
+import org.apache.bookkeeper.common.concurrent.FutureUtils;
+import org.apache.bookkeeper.common.util.OrderedScheduler;
+import org.apache.bookkeeper.net.BookieSocketAddress;
+import org.apache.bookkeeper.proto.BookieClient;
+import org.apache.bookkeeper.proto.BookkeeperInternalCallbacks.ReadEntryCallback;
+import org.apache.bookkeeper.proto.checksum.DigestManager;
+import org.apache.bookkeeper.proto.checksum.DummyDigestManager;
+import org.apache.bookkeeper.test.TestStatsProvider;
+import org.apache.bookkeeper.test.TestStatsProvider.TestOpStatsLogger;
+import org.apache.bookkeeper.util.ByteBufList;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Unit test {@link ReadLastConfirmedAndEntryOp} with mocks.
+ */
+@Slf4j
+public class ReadLastConfirmedAndEntryOpTest {
+
+    private static final long LEDGERID = System.currentTimeMillis();
+
+    private final TestStatsProvider testStatsProvider = new TestStatsProvider();
+    private TestOpStatsLogger readLacAndEntryOpLogger;
+    private BookieClient mockBookieClient;
+    private BookKeeper mockBk;
+    private LedgerHandle mockLh;
+    private ScheduledExecutorService scheduler;
+    private OrderedScheduler orderedScheduler;
+    private SpeculativeRequestExecutionPolicy speculativePolicy;
+    private LedgerMetadata ledgerMetadata;
+    private DistributionSchedule distributionSchedule;
+    private DigestManager digestManager;
+
+    @Before
+    public void setup() throws Exception {
+        // stats
+        this.readLacAndEntryOpLogger = testStatsProvider.getOpStatsLogger("readLacAndEntry");
+        // policy
+        this.speculativePolicy = new DefaultSpeculativeRequestExecutionPolicy(
+            100, 200, 2);
+        // metadata
+        this.ledgerMetadata =
+            new LedgerMetadata(3, 3, 2, DigestType.CRC32, new byte[0]);
+        ArrayList<BookieSocketAddress> ensemble = new ArrayList<>(3);
+        for (int i = 0; i < 3; i++) {
+            ensemble.add(new BookieSocketAddress("127.0.0.1", 3181 + i));
+        }
+        this.ledgerMetadata.addEnsemble(0L, ensemble);
+        this.distributionSchedule = new RoundRobinDistributionSchedule(3, 3, 2);
+        // schedulers
+        this.scheduler = Executors.newSingleThreadScheduledExecutor();
+        this.orderedScheduler = OrderedScheduler.newSchedulerBuilder()
+            .name("test-ordered-scheduler")
+            .numThreads(1)
+            .build();
+
+        this.mockBookieClient = mock(BookieClient.class);
+
+        this.mockBk = mock(BookKeeper.class);
+        when(mockBk.getReadLACSpeculativeRequestPolicy()).thenReturn(Optional.of(speculativePolicy));
+        when(mockBk.getBookieClient()).thenReturn(mockBookieClient);
+        when(mockBk.getReadLacAndEntryOpLogger()).thenReturn(readLacAndEntryOpLogger);
+        when(mockBk.getMainWorkerPool()).thenReturn(orderedScheduler);
+        this.mockLh = mock(LedgerHandle.class);
+        when(mockLh.getBk()).thenReturn(mockBk);
+        when(mockLh.getId()).thenReturn(LEDGERID);
+        when(mockLh.getLedgerMetadata()).thenReturn(ledgerMetadata);
+        when(mockLh.getDistributionSchedule()).thenReturn(distributionSchedule);
+        digestManager = new DummyDigestManager(LEDGERID, false);
+        when(mockLh.getDigestManager()).thenReturn(digestManager);
+    }
+
+    @After
+    public void teardown() {
+        this.scheduler.shutdown();
+        this.orderedScheduler.shutdown();
+    }
+
+    /**
+     * Test case: handling different speculative responses. one speculative response might return a valid response
+     * with a read entry, while the other speculative response might return a valid response without an entry.
+     * {@link ReadLastConfirmedAndEntryOp} should handle both responses well.
+     *
+     * <p>This test case covers {@link https://github.com/apache/bookkeeper/issues/1476}.
+     */
+    @Test
+    public void testSpeculativeResponses() throws Exception {
+        final long entryId = 3L;
+        final long lac = 2L;
+
+        ByteBuf data = Unpooled.copiedBuffer("test-speculative-responses", UTF_8);
+        ByteBufList dataWithDigest = digestManager.computeDigestAndPackageForSending(
+            entryId, lac, data.readableBytes(), data);
+        byte[] bytesWithDigest = new byte[dataWithDigest.readableBytes()];
+        assertEquals(bytesWithDigest.length, dataWithDigest.getBytes(bytesWithDigest));
+
+        final Map<BookieSocketAddress, ReadEntryCallback> callbacks = Collections.synchronizedMap(new HashMap<>());
+        doAnswer(invocationOnMock -> {
+            BookieSocketAddress address = invocationOnMock.getArgument(0);
+            ReadEntryCallback callback = invocationOnMock.getArgument(6);
+
+            log.info("Received read request to bookie {}", address);
+
+            callbacks.put(address, callback);
+            return null;
+        }).when(mockBookieClient).readEntryWaitForLACUpdate(
+            any(BookieSocketAddress.class),
+            anyLong(),
+            anyLong(),
+            anyLong(),
+            anyLong(),
+            anyBoolean(),
+            any(ReadEntryCallback.class),
+            any()
+        );
+
+        CompletableFuture<LastConfirmedAndEntry> resultFuture = new CompletableFuture<>();
+        LastConfirmedAndEntryCallback resultCallback = (rc, lastAddConfirmed, entry) -> {
+            if (Code.OK != rc) {
+                FutureUtils.completeExceptionally(resultFuture, BKException.create(rc));
+            } else {
+                FutureUtils.complete(resultFuture, LastConfirmedAndEntryImpl.create(lastAddConfirmed, entry));
+            }
+        };
+
+        ReadLastConfirmedAndEntryOp op = new ReadLastConfirmedAndEntryOp(
+            mockLh,
+            resultCallback,
+            1L,
+            10000,
+            scheduler
+        );
+        op.initiate();
+
+        // wait until all speculative requests are sent
+        while (callbacks.size() < 3) {
+            log.info("Received {} read requests", callbacks.size());
+            Thread.sleep(100);
+        }
+
+        log.info("All speculative reads are outstanding now.");
+    }
+
+}


### PR DESCRIPTION
Descriptions of the changes in this PR:



### Motivation

There are two flags on checking whether a request is completed. That is being misued for two different branches,
one is when the request is completed with advanced lac but no entry piggybacked, the other one is when the request
is completed with adavanced lac with an entry piggybacked. When this happen, it will cause a request being completed
twice and the entry buffer is recycled twice.

### Changes

Remove direct usage of submitCallback and use completeRequest instead.

Add a unit test for reproduce the issue and ensure the fix address the problem.

> ---
> In order to uphold a high standard for quality for code contributions, Apache BookKeeper runs various precommit
> checks for pull requests. A pull request can only be merged when it passes precommit checks. However running all
> the precommit checks can take a long time, some trivial changes don't need to run all the precommit checks. You
> can check following list to skip the tests that don't need to run for your pull request. Leave them unchecked if
> you are not sure, committers will help you:
>
> - [ ] [skip bookkeeper-server bookie tests]: skip testing `org.apache.bookkeeper.bookie` in bookkeeper-server module.
> - [ ] [skip bookkeeper-server client tests]: skip testing `org.apache.bookkeeper.client` in bookkeeper-server module.
> - [ ] [skip bookkeeper-server replication tests]: skip testing `org.apache.bookkeeper.replication` in bookkeeper-server module.
> - [ ] [skip bookkeeper-server tls tests]: skip testing `org.apache.bookkeeper.tls` in bookkeeper-server module.
> - [ ] [skip bookkeeper-server remaining tests]: skip testing all other tests in bookkeeper-server module.
> - [ ] [skip integration tests]: skip docker based integration tests. if you make java code changes, you shouldn't skip integration tests.
> - [ ] [skip build java8]: skip build on java8. *ONLY* skip this when *ONLY* changing files under documentation under `site`.
> - [ ] [skip build java9]: skip build on java9. *ONLY* skip this when *ONLY* changing files under documentation under `site`.
> ---

> ---
> Be sure to do all of the following to help us incorporate your contribution
> quickly and easily:
>
> If this PR is a BookKeeper Proposal (BP):
>
> - [ ] Make sure the PR title is formatted like:
>     `<BP-#>: Description of bookkeeper proposal`
>     `e.g. BP-1: 64 bits ledger is support`
> - [ ] Attach the master issue link in the description of this PR.
> - [ ] Attach the google doc link if the BP is written in Google Doc.
>
> Otherwise:
> 
> - [ ] Make sure the PR title is formatted like:
>     `<Issue #>: Description of pull request`
>     `e.g. Issue 123: Description ...`
> - [ ] Make sure tests pass via `mvn clean apache-rat:check install spotbugs:check`.
> - [ ] Replace `<Issue #>` in the title with the actual Issue number.
> 
> ---
